### PR TITLE
Duplicate Section Handling and Final extraction format enforcement

### DIFF
--- a/document_splitter.py
+++ b/document_splitter.py
@@ -27,13 +27,6 @@ def split_document_into_sections(document_name, input_toc_folder, input_txt_fold
     pages = text.split("Page Number ")[1:]
     pages = ["Page Number " + page for page in pages]
 
-    # print(len(pages))
-    # print("^"*100)
-    # print(pages[0])
-    # print("^"*100)
-    # print(pages[1])
-    # print("^"*100)
-    # print(pages[2])
 
     # Iterate through each section in the TOC
     for section_name, page_range in toc.items():
@@ -69,10 +62,6 @@ if __name__ == "__main__":
     else:
         print("Error loading config file!")
         # Handle the error gracefully, e.g., exit or provide a default value
-
-    # Get the input and output folder for pdfs
-    pdf_input_folders = config.get("input_folders")
-    pdf_output_folder = config.get("output_folder")
 
     # Specify input and output folder paths (replace with actual paths)
     input_toc_folder = config.get("toc_json")

--- a/document_splitter.py
+++ b/document_splitter.py
@@ -6,6 +6,9 @@ def load_config(file_path):
     with open(file_path, "r", encoding="utf-8") as f:
         return yaml.safe_load(f)
     
+import re
+import os
+
 def split_document_into_sections(document_name, input_toc_folder, input_txt_folder, output_txt_folder):
     """Splits a document into sections based on the provided JSON structure."""
 
@@ -15,9 +18,29 @@ def split_document_into_sections(document_name, input_toc_folder, input_txt_fold
     json_file_path = os.path.join(input_toc_folder, f"{document_name}.json")
     text_file_path = os.path.join(input_txt_folder, f"{document_name}.txt")
 
-    # Load the TOC JSON data
+    # Load the TOC content using regex (non-recursive pattern)
     with open(json_file_path, "r") as f:
-        toc = json.load(f)
+        json_content = f.read()
+        pattern = r'"([^"]*)":\s*\[(.*?)\]'  # Match key-value pairs directly
+        matches = re.findall(pattern, json_content)
+
+    # print("mathches: ", matches )
+    toc = {}
+    for key, value_str in matches:
+        # print(key, value_str)
+        values = []
+        for sublist_str in value_str.split("], "):  # Split nested lists
+            for item in sublist_str.strip("[]").split(","):
+                try:
+                    values.append(int(item))  # Convert to int if possible
+                except ValueError:
+                    values.append(None)  # Handle null values
+        if key in toc:
+            toc[key].append(values)  # Append to existing list for duplicates
+        else:
+            toc[key] = [values]
+
+    # print("toc: ", toc)
 
     # Read the text content of the document
     with open(text_file_path, "r") as f:
@@ -27,22 +50,25 @@ def split_document_into_sections(document_name, input_toc_folder, input_txt_fold
     pages = text.split("Page Number ")[1:]
     pages = ["Page Number " + page for page in pages]
 
-
     # Iterate through each section in the TOC
-    for section_name, page_range in toc.items():
-        # Extract and adjust page range indices for zero-based indexing
-        start_page = page_range[0] - 1
-        end_page = page_range[1] if page_range[1] else len(pages)  # Handle open-ended ranges
+    for section_name in toc.keys():
+        for page_range in toc[section_name]:
+            # Extract and adjust page range indices for zero-based indexing
+            start_page = page_range[0] - 1
+            end_page = page_range[1] if page_range[1] else len(pages)  # Handle open-ended ranges
 
-        # Extract the text for the current section from the pages list
-        section_text = "\n".join(pages[start_page:end_page])
+            # Extract the text for the current section from the pages list
+            section_text = "\n".join(pages[start_page:end_page])
 
-        # Construct the output file path for the section
-        output_file_path = os.path.join(output_txt_folder, f"{document_name}_{section_name}.txt")
+            # Construct the output file path, incorporating start and end pages
+            output_file_path = os.path.join(output_txt_folder, f"{document_name}_{section_name}_{start_page+1}_{end_page}.txt")
 
-        # Write the section text to the output file
-        with open(output_file_path, "w") as f:
-            f.write(section_text)
+            # print(f"section_name: {section_name}\npage_range: {page_range}\noutput_file_path: {output_file_path}\n")
+
+            # Write the section text to the output file
+            with open(output_file_path, "w") as f:
+                f.write(section_text)
+
     
 if __name__ == "__main__":
 
@@ -74,4 +100,4 @@ if __name__ == "__main__":
 
     # Iterate through each document and split it into sections
     for document_name in document_names:
-        split_document_into_sections(document_name, input_toc_folder, input_txt_folder, output_txt_folder)
+        split_document_into_sections(document_name, input_toc_folder, input_txt_folder, input_txt_folder)

--- a/final_txt_formatter_with_sections.py
+++ b/final_txt_formatter_with_sections.py
@@ -1,0 +1,61 @@
+import os
+import re
+import random
+from utils.helpers import load_config
+
+def section_formatter(input_folder, output_folder):
+   """Processes .txt files in the given folder, ensuring they have the required format."""
+ 
+   regex = r"^(\d+\.\d+) --- (.+?)$"# Regex to match the required format
+
+   for filename in os.listdir(input_folder):
+       if filename.endswith(".txt"):
+           input_file_path = os.path.join(input_folder, filename)
+           output_file_path = os.path.join(output_folder, filename)
+
+           with open(input_file_path, "r") as input_file:
+               first_line = input_file.readline().strip()
+
+               if re.match(regex, first_line):
+                   # File already has the required format, copy it directly
+                   with open(output_file_path, "w") as output_file:
+                       output_file.write(input_file.read())
+               else:
+                   # Generate section number
+                   s1 = random.randint(1, 10)
+                   s2 = random.randint(1, 10)
+                   section_number = f"{s1}.{s2}"
+
+                   # Get file name without extension
+                   file_name_without_ext = os.path.splitext(filename)[0]
+
+                   # Modify the file content
+                   content = input_file.read()
+                   modified_content = f"{section_number} --- {file_name_without_ext}\n\n{first_line}\n{content}"
+
+                   # Write the modified content to the output file
+                   with open(output_file_path, "w") as output_file:
+                       output_file.write(modified_content)
+
+
+if __name__ == "__main__":
+
+    config_file = "./config.yaml"
+
+    if os.path.exists(config_file):
+        print(f"{config_file} exists!")
+    else:
+        print(f"{config_file} does not exist.")
+
+    # Load parameters from config.yml
+    config = load_config(config_file)
+
+    if config is not None:
+        # Get the input and output folder for pdfs
+        input_txt_folder_path = config.get("extracted_txt")# Specify the folder path
+        outpt_txt_folder_path = config.get("final_ext_txt")# Specify the folder path
+    else:
+        print("Error loading config file!")
+        # Handle the error gracefully, e.g., exit or provide a default value
+
+    section_formatter(input_txt_folder_path, outpt_txt_folder_path)

--- a/pdf_parser.py
+++ b/pdf_parser.py
@@ -5,29 +5,9 @@ import argparse
 import yaml
 parent_dir = "."
 sys.path.append(parent_dir)
+from utils.helpers import load_config, print_yaml_content
 from utils.docAI_extraction import process_local_document_in_chunks
 from utils.table_extraction import get_latex_tables_camelot, get_pdf_table_latex, extract_and_clean_tables
-# import argo_utils
-
-def print_yaml_content(file_path):
-    """Prints the content of a YAML file in a human-readable format."""
-
-    try:
-        with open(file_path, "r") as file:
-            yaml_data = yaml.safe_load(file)
-
-        # Print the parsed YAML data in a user-friendly way
-        print(f"Content from {file_path}: \n")
-        print(yaml.dump(yaml_data, default_flow_style=False))
-
-    except FileNotFoundError:
-        print(f"Error: File '{file_path}' not found.")
-    except yaml.YAMLError as exc:
-        print(f"Error parsing YAML file: {exc}")
-
-def load_config(file_path):
-    with open(file_path, "r", encoding="utf-8") as f:
-        return yaml.safe_load(f)
 
 def extract_pdf(input_folder, output_folder, redo_extract):
     
@@ -91,26 +71,24 @@ if __name__ == "__main__":
     config = load_config(config_file)
 
     if config is not None:
-        pdf_input_folders = config.get("input_folders")
-        # Proceed with using pdf_input_folders
+        # Get the input and output folder for pdfs
+        pdf_input_folder = config.get("raw_data")
+        pdf_output_folder = config.get("extracted_txt")
+        print(f"Processing pdf files from {pdf_input_folder}")
+        
+        # GCP creds/Info
+        project_id = config.get("project_id")
+        location = config.get("location")
+        processor_id = config.get("processor_id")
+        mime_type = config.get("mime_type")
+
+        # Process paramaters
+        redo_extract = config.get("redo_extract")
     else:
         print("Error loading config file!")
         # Handle the error gracefully, e.g., exit or provide a default value
 
-    # Get the input and output folder for pdfs
-    pdf_input_folder = config.get("raw_data")
-    pdf_output_folder = config.get("extracted_txt")
-    print(f"Processing pdf files from {pdf_input_folder}")
     
-    # GCP creds/Info
-    project_id = config.get("project_id")
-    location = config.get("location")
-    processor_id = config.get("processor_id")
-    mime_type = config.get("mime_type")
-
-    # Process paramaters
-    redo_extract = config.get("redo_extract")
-
     # Check to make sure input folder exists and create output folder if it does not exist
     if not os.path.exists(pdf_input_folder):
         print(f"{pdf_input_folder} does not exists!")

--- a/scratch_pad.py
+++ b/scratch_pad.py
@@ -1,0 +1,18 @@
+import json
+
+data = json.loads("""{ "Markdown ": [2, 3],
+    "Grocery": [3, 4],
+    "Reduced for Quick Sale": [4, 5],
+    "Grocery": [5, 6],
+"Grocery": [5, 6]}""")
+
+print(data)
+
+processed_data = {}
+for key, value in data.items():
+    if key not in processed_data:
+        processed_data[key] = [value]
+    else:
+        processed_data[key].append(value)
+
+print(json.dumps(processed_data, indent=4))

--- a/upload_resources.sh
+++ b/upload_resources.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 # Upload resource files to GCS.
-gsutil -m cp -r /mnt/resources/woolworths/extracted_text/* "gs://woolworths_argo/extracted_text/"
-gsutil -m cp -r /mnt/resources/woolworths/extracted_text_teamcare_format/* "gs://woolworths_argo/extracted_text_teamcare_format/"
+gsutil -m cp -r /mnt/resources/woolworths/extracted_txt/* "gs://woolworths_argo/extracted_txt/"
+gsutil -m cp -r /mnt/resources/woolworths/extracted_txt_teamcare_format/* "gs://woolworths_argo/extracted_txt_teamcare_format/"
 gsutil -m cp -r /mnt/resources/woolworths/toc_json/* "gs://woolworths_argo/toc_json/"

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -1,0 +1,21 @@
+import yaml
+
+def load_config(file_path):
+    with open(file_path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+    
+def print_yaml_content(file_path):
+    """Prints the content of a YAML file in a human-readable format."""
+
+    try:
+        with open(file_path, "r") as file:
+            yaml_data = yaml.safe_load(file)
+
+        # Print the parsed YAML data in a user-friendly way
+        print(f"Content from {file_path}: \n")
+        print(yaml.dump(yaml_data, default_flow_style=False))
+
+    except FileNotFoundError:
+        print(f"Error: File '{file_path}' not found.")
+    except yaml.YAMLError as exc:
+        print(f"Error parsing YAML file: {exc}")


### PR DESCRIPTION
- moved some common functions to helpers.py
- moved common function to helper.py from pdf_parser and fixed an issue with parameter reading from config file
- document_splitter can now handle duplicate section names in the TOC json file; The final section naming convention now incluses start-stop pages in addition to section name to handle the duplicate section names
- created final_txt_formatter_with_sections.py that will look through the extracted txt for the required format and enforces it before writing to final formatted extraction folder